### PR TITLE
Modfiy creating git URL in git-pr

### DIFF
--- a/git-pr
+++ b/git-pr
@@ -34,7 +34,7 @@ fi
 # Compare url 만들고 브라우저로 열기
 
 GITHUB_ID=$(git config --get remote.origin.url | sed -e 's/^[^:]*://' | sed -e 's/.git$//' | sed -e 's/^[^:]*github.com\///')
-URL="https://github.com/$GITHUB_ID/compare/$BR_MASTER...$CURRENT"
+URL="https://github.com/$GITHUB_ID/compare/$CURRENT?expand=1"
 
 case $(uname -s) in
 "Darwin")

--- a/git-pr
+++ b/git-pr
@@ -33,7 +33,7 @@ fi
 
 # Compare url 만들고 브라우저로 열기
 
-GITHUB_ID=$(git config --get remote.origin.url | sed -e 's/^[^:]*://' | sed -e 's/.git$//')
+GITHUB_ID=$(git config --get remote.origin.url | sed -e 's/^[^:]*://' | sed -e 's/.git$//' | sed -e 's/^[^:]*github.com\///')
 URL="https://github.com/$GITHUB_ID/compare/$BR_MASTER...$CURRENT"
 
 case $(uname -s) in


### PR DESCRIPTION
git-pr 명령어 사용시 git config --get remote.origin.url의 결과에 따라서, "//github.com"가 중복되어서 pull request 페이지를 열어줄 url이 잘못 생성되는 경우가 있는 듯합니다. Not found 페이지가 뜨는 경우가 있었습니다.

eg. git config --get remote.origin.url 
=> https://github.com/8percent/github-flow-sugar.git

결과 
https://github.com///github.com/8percent/github-flow-sugar/compare/...

GITHUB_ID에서 "//github.com"가 남아있는 경우 삭제하도록 수정하였습니다.