### PR TITLE
allow bother base branch than MASTER

### DIFF
--- a/git-pr
+++ b/git-pr
@@ -1,12 +1,15 @@
 #!/bin/bash
 
-if [ $# -ne 0 ]
+if [[ $# == 0 ]]
 then
-  echo "usage: $(basename $0)"
+  BR_BASE="master"
+elif [[ $# == 1 ]]
+then
+  BR_BASE="$1"
+else
+  echo "usage: $(basename $0) YOUR_BASE_BRANCH"
   exit 1
 fi
-
-BR_MASTER="master"
 
 CURRENT=$(git rev-parse --abbrev-ref HEAD)
 
@@ -46,7 +49,7 @@ else
 fi
 
 BODY_QUERY+=$(echo "$BODY" | perl -MURI::Escape -ne 'chomp;$str = uri_escape($_); $str =~ s/%5Cn/%0A/ig; print $str')
-URL="https://github.com/$GITHUB_ID/compare/master...$CURRENT?expand=1&body=$BODY_QUERY"
+URL="https://github.com/$GITHUB_ID/compare/$BR_BASE...$CURRENT?expand=1&body=$BODY_QUERY"
 
 case $(uname -s) in
 "Darwin")


### PR DESCRIPTION
iOS에서 개발된 내용을 develop에 먼저 머지한 후에 일정 주기로 master로 배포하려고 합니다.
master에 바로 머지하는 github flow랑 추구하는 본질이 조금 달라지기는 한데, JIRA 관련 커맨드 작업해주신 git-feature 커맨드랑 같이 유용하게 쓸 수 있을 것 같아서 따로 포크 안 뜨고 여기에 작업했습니다.